### PR TITLE
A better way of getting _id at the end of node.self.

### DIFF
--- a/main.js
+++ b/main.js
@@ -1447,9 +1447,7 @@ Neo4j.prototype.getId = function(url, length){
 
 Neo4j.prototype.addNodeId = function(node, callback){	
 	if (node && node.self) {
-		node.data._id = parseInt(node.self
-					.replace(this.removeCredentials(this.url) + '/db/data/node/', '')
-					.replace(this.removeCredentials(this.url) + '/db/data/relationship/', ''));  
+		node.data._id = parseInt(node.self.match(/\/([0-9]+)$/)[1]);
 		callback(null, node.data);
 	} else
 		callback(null, node);


### PR DESCRIPTION
I'm getting `{name: 'Testing Testsson', _id:NaN}` when calling `db.insertNode({name: 'Testing Testsson'}, function(err, res) { console.log(res) })`.

I'm running `node-neo4j v2.0.0-RC1` and `neo4j v1.9.5`.

This way, just getting all the digits from the end of the `node.self` seems like a better idea.

Would you agree?
