### PR TITLE
Added option to get stats returned when running a cypher query.

### DIFF
--- a/main.js
+++ b/main.js
@@ -1349,7 +1349,7 @@ Neo4j.prototype.readOutgoingRelationshipsOfNode = function(node_id, callback){
 
 /* Run Cypher Query -------- */
 
-Neo4j.prototype.cypherQuery = function(query, params, callback, include_stats){
+Neo4j.prototype.cypherQuery = function(query, params, include_stats, callback){
 	var that = this;
 	var body = { query: query };
 	if(params) {
@@ -1357,7 +1357,13 @@ Neo4j.prototype.cypherQuery = function(query, params, callback, include_stats){
 			callback = params;
 		else
 			body['params'] = params;
-	} 
+	}
+	if(include_stats) {
+		if (typeof include_stats === 'function') {
+			callback = include_stats;
+			include_stats = false;
+		}
+	}
 
 	request
 		.post(that.url + '/db/data/cypher' + (include_stats ? '?includeStats=true' : ''))


### PR DESCRIPTION
I recently had to run `CREATE UNIQUE` for relationships and the only way to find out if a relation was created is to get hold of te stats and look at `stats.relationships_created` like this:

```
db.cypherQuery(q, {}, function(err, res) {
    if(res.stats.relationships_created > 0) {
        //Relation created
    }
})
```

I wasn't sure where you wanted this setting to be set, but since it's not very common I figured that it's easiest just to add it as a parameter to the function call.
