### PR TITLE
added 204 to the valid response cases for listing indexes.

### DIFF
--- a/main.js
+++ b/main.js
@@ -446,6 +446,7 @@ function listIndexes (url, callback) {
 		.end(function(result){
 		switch(result.statusCode){
 			case 200:
+			case 204:
 				callback(null, result.body);
 				break;
 			case 404:


### PR DESCRIPTION
This tripped me up for a moment,
Listing indexes when there aren't any returns a `204`, which was handled as an error case when it isn't.
In my use case (scaffolding, frequently rebuilding from scratch), the empty object is desired.  

<!---
@huboard:{"order":39.0,"milestone_order":39,"custom_state":""}
-->
