### PR TITLE
allow Neo4j URLs with trailing forward slash

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -11,7 +11,7 @@ module.exports = Neo4j;
 
 function Neo4j(url){
 	if(typeof url !== 'undefined' && url !== ''){
-		this.url = url;
+		this.url = url.slice(-1) !== '/' ? url : url.slice(0, -1); // remove trailing forward slash if present
 	} else {
 		this.url = 'http://localhost:7474';
 	}


### PR DESCRIPTION
If an url like `http://localhost:7474/` is used (note the trailing forward slash), then you get `null` back on a cypher query (and probably others) because the url then contains `//`. This is a quick fix to resolve that issue.

Not sure if the returning of `null` on a 404 is appropriate, maybe that should be fixed as well in the future.