### PR TITLE
Added error handling to request callbacks.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -45,9 +45,11 @@ Neo4j.prototype.insertNode = function(node, labels, callback){
 			.post(this.url + '/db/data/node')
 			.set(this.header)
 			.send(node)
-			.end(function(result){
-				if(result.body && result.body.data) {
+			.end(function(err, result){
+				if(result && result.body && result.body.data) {
 					that.addNodeId(result.body, callback);
+                } else if(err) {
+                    callback(err);
 				} else {
 					callback(new Error('Response body is empty'), null);
 				}
@@ -91,9 +93,11 @@ Neo4j.prototype.readLabels = function(node_id, callback){
 	request
 		.get(this.url + '/db/data/node/' + node_id + '/labels')
 		.set(this.header)
-		.end(function(result){
-			if(result.body) {
+		.end(function(err, result){
+			if(result && result.body) {
 				callback(null, result.body);
+            } else if(err) {
+                callback(err);
 			} else {
 				callback(new Error('Response is empty'), null);
 			}
@@ -108,20 +112,24 @@ Neo4j.prototype.deleteNode = function(node_id, callback){
 	request
 		.del(this.url + '/db/data/node/' + node_id)
 		.set(this.header)
-		.end(function(result){
-			switch(result.statusCode){
-				case 204:
-					callback(null, true); // Node was deleted.
-					break;
-				case 404:
-					callback(null, false); // Node doesn't exist.
-					break;
-				case 409:
-					callback(null, false); // Node has Relationships and cannot be deleted.
-					break;
-				default:
-					callback(new Error('HTTP Error ' + result.statusCode + ' occurred while deleting a node.'), null);
-			}
+		.end(function(err, result){
+            if(err) {
+                callback(err);
+            } else {
+                switch(result.statusCode){
+                    case 204:
+                        callback(null, true); // Node was deleted.
+                        break;
+                    case 404:
+                        callback(null, false); // Node doesn't exist.
+                        break;
+                    case 409:
+                        callback(null, false); // Node has Relationships and cannot be deleted.
+                        break;
+                    default:
+                        callback(new Error('HTTP Error ' + result.statusCode + ' occurred while deleting a node.'), null);
+                }
+            }
 		});
 };
 
@@ -161,17 +169,21 @@ Neo4j.prototype.readNode = function(node_id, callback) {
 	request
 		.get(this.url + '/db/data/node/' + node_id)
 		.set(this.header)
-		.end(function(result) {
-			switch(result.statusCode) {
-				case 200:
-					that.addNodeId(result.body, callback); // Node found.
-					break;
-				case 404:
-					callback(null, false); // Node doesn't exist.
-					break;
-				default:
-					callback(new Error('HTTP Error ' + result.statusCode + ' occurred while reading a node.'), null);
-			}
+		.end(function(err, result) {
+            if(err) {
+                callback(err);
+            } else {
+                switch(result.statusCode) {
+                    case 200:
+                        that.addNodeId(result.body, callback); // Node found.
+                        break;
+                    case 404:
+                        callback(null, false); // Node doesn't exist.
+                        break;
+                    default:
+                        callback(new Error('HTTP Error ' + result.statusCode + ' occurred while reading a node.'), null);
+                }
+            }
 		});
 };
 
@@ -184,17 +196,21 @@ var replaceNodeById = function(node_id, node_data, callback) {
     .put(that.url + '/db/data/node/' + node_id + '/properties')
 	.set(this.header)
     .send(that.stringifyValueObjects(that.replaceNullWithString(node_data)))
-		.end(function(result) {
-      switch(result.statusCode) {
-        case 204:
-          callback(null, true);
-          break;
-        case 404:
-          callback(null, false);
-          break;
-        default:
-          callback(new Error('HTTP Error ' + result.statusCode + ' when updating a Node.'), null);
-      }
+		.end(function(err, result) {
+            if(err) {
+                callback(err);
+            } else {
+                switch(result.statusCode) {
+                    case 204:
+                        callback(null, true);
+                        break;
+                    case 404:
+                        callback(null, false);
+                        break;
+                    default:
+                        callback(new Error('HTTP Error ' + result.statusCode + ' when updating a Node.'), null);
+                }
+            }
     });
 };
 // Create an alias
@@ -277,20 +293,24 @@ Neo4j.prototype.insertRelationship = function(root_node_id, other_node_id, relat
 			type: relationship_type,
 			data: that.stringifyValueObjects(that.replaceNullWithString(relationship_data))
 		})
-		.end(function(result) {
-			switch(result.statusCode) {
-				case 201:
-					that.addRelationshipId(result.body, callback);
-					break;
-				case 400: // Endnode not found exception
-					callback(null, false);
-					break;
-				case 404: // Startnode not found exception
-					callback(null, false);
-					break;
-				default:
-					callback(new Error('HTTP Error ' + result.statusCode + ' when inserting a Relationship.'), null);
-			}
+		.end(function(err, result) {
+            if(err) {
+                callback(err);
+            } else {
+                switch(result.statusCode) {
+                    case 201:
+                        that.addRelationshipId(result.body, callback);
+                        break;
+                    case 400: // Endnode not found exception
+                        callback(null, false);
+                        break;
+                    case 404: // Startnode not found exception
+                        callback(null, false);
+                        break;
+                    default:
+                        callback(new Error('HTTP Error ' + result.statusCode + ' when inserting a Relationship.'), null);
+                }
+            }
 		});
 };
 
@@ -301,17 +321,21 @@ Neo4j.prototype.deleteRelationship = function(relationship_id, callback) {
 	request
 		.del(that.url + '/db/data/relationship/' + relationship_id)
 		.set(this.header)
-		.end(function(result) {
-			switch(result.statusCode) {
-				case 204:
-					callback(null, true);
-					break;
-				case 404: // Relationship with that id doesn't exist.
-					callback(null, false);
-					break;
-				default:
-					callback(new Error('HTTP Error ' + result.statusCode + ' when deleting a Relationship.'), null);
-			}
+		.end(function(err, result) {
+            if(err) {
+                callback(err);
+            } else {
+                switch(result.statusCode) {
+                    case 204:
+                        callback(null, true);
+                        break;
+                    case 404: // Relationship with that id doesn't exist.
+                        callback(null, false);
+                        break;
+                    default:
+                        callback(new Error('HTTP Error ' + result.statusCode + ' when deleting a Relationship.'), null);
+                }
+            }
 		});
 };
 
@@ -323,17 +347,21 @@ Neo4j.prototype.readRelationship = function(relationship_id, callback) {
 	request
 		.get(that.url + '/db/data/relationship/' + relationship_id)
 		.set(this.header)
-		.end(function(result) {
-			switch(result.statusCode) {
-				case 200:
-					that.addRelationshipId(result.body, callback);
-					break;
-				case 404:
-					callback(null, false);
-					break;
-				default:
-					callback(new Error('HTTP Error ' + result.statusCode + ' when reading a Relationship'), null);
-			}
+		.end(function(err, result) {
+            if(err) {
+                callback(err);
+            } else {
+                switch(result.statusCode) {
+                    case 200:
+                        that.addRelationshipId(result.body, callback);
+                        break;
+                    case 404:
+                        callback(null, false);
+                        break;
+                    default:
+                        callback(new Error('HTTP Error ' + result.statusCode + ' when reading a Relationship'), null);
+                }
+            }
 		});
 };
 
@@ -346,17 +374,21 @@ Neo4j.prototype.updateRelationship = function(relationship_id, relationship_data
 		.put(that.url + '/db/data/relationship/' + relationship_id + '/properties')
 		.set(this.header)
 		.send(that.stringifyValueObjects(that.replaceNullWithString(relationship_data)))
-		.end(function(result) {
-			switch(result.statusCode) {
-				case 204:
-					callback(null, true);
-					break;
-				case 404:
-					callback(null, false);
-					break;
-				default:
-					callback(new Error('HTTP Error ' + result.statusCode + ' when updating a Relationship.'), null);
-			}
+		.end(function(err, result) {
+            if(err) {
+                callback(err);
+            } else {
+                switch(result.statusCode) {
+                    case 204:
+                        callback(null, true);
+                        break;
+                    case 404:
+                        callback(null, false);
+                        break;
+                    default:
+                        callback(new Error('HTTP Error ' + result.statusCode + ' when updating a Relationship.'), null);
+                }
+            }
 		});
 };
 
@@ -372,17 +404,21 @@ Neo4j.prototype.insertIndex = function(index, callback) {
 			'name': index.index,
 			'config': index.config
 		})
-		.end(function(result) {
-			switch(result.statusCode) {
-				case 201:
-					callback(null, result.body);
-					break;
-				case 404:
-					callback(null, false);
-					break;
-				default:
-					callback(new Error('HTTP Error ' + result.statusCode + ' when inserting an Index.'), null);
-			}
+		.end(function(err, result) {
+            if(err) {
+                callback(err);
+            } else {
+                switch(result.statusCode) {
+                    case 201:
+                        callback(null, result.body);
+                        break;
+                    case 404:
+                        callback(null, false);
+                        break;
+                    default:
+                        callback(new Error('HTTP Error ' + result.statusCode + ' when inserting an Index.'), null);
+                }
+            }
 		});
 };
 
@@ -400,16 +436,18 @@ Neo4j.prototype.insertIndex = function(index, callback) {
 
 Neo4j.prototype.insertLabelIndex = function(label, property_key, callback) {
 	request
-			.post(this.url + '/db/data/schema/index/' + label)
-			.set(this.header)
-			.send({ 'property_keys' : [property_key] })
-			.end(function(result){
-				if(result.body) {
-					callback(null, result.body);
-				} else {
-					callback(new Error('Response is empty'), null);
-				}
-	});
+        .post(this.url + '/db/data/schema/index/' + label)
+        .set(this.header)
+        .send({ 'property_keys' : [property_key] })
+        .end(function(err, result){
+            if(err) {
+                callback(err);
+            } else if(result.body) {
+                callback(null, result.body);
+            } else {
+                callback(new Error('Response is empty'), null);
+            }
+        });
 };
 
 Neo4j.prototype.insertNodeIndex = function(index, callback) {
@@ -440,18 +478,22 @@ Neo4j.prototype.deleteIndex = function(index, callback) {
 	request
 		.del(this.url + '/db/data/index/' + index.type + '/' + index.index)
 		.set(this.header)
-		.end(function(result) {
-			switch(result.statusCode) {
-				case 204:
-					callback(null, true); // Index was deleted.
-					break;
-				case 404:
-					callback(null, false); // Index doesn't exist.
-					break;
-				default:
-					callback(new Error('Unknown Error while deleting Index'), null);
-			}
-	});
+		.end(function(err, result) {
+            if(err) {
+                callback(err);
+            } else {
+                switch(result.statusCode) {
+                    case 204:
+                        callback(null, true); // Index was deleted.
+                        break;
+                    case 404:
+                        callback(null, false); // Index doesn't exist.
+                        break;
+                    default:
+                        callback(new Error('Unknown Error while deleting Index'), null);
+                }
+            }
+	    });
 };
 
 Neo4j.prototype.deleteNodeIndex = function(index, callback) {
@@ -464,39 +506,47 @@ Neo4j.prototype.deleteRelationshipIndex = function(index, callback) {
 
 Neo4j.prototype.deleteLabelIndex = function(label, property_key, callback) {
 	request
-	.del(this.url + '/db/data/schema/index/' + label + '/' + property_key)
-	.set(this.header)
-	.end(function(result) {
-		switch(result.statusCode) {
-			case 204:
-				callback(null, true); // Index was deleted.
-				break;
-			case 404:
-				callback(null, false); // Index doesn't exist.
-				break;
-			default:
-				callback(new Error('Unknown Error while deleting Index'), null);
-		}
-	});
+        .del(this.url + '/db/data/schema/index/' + label + '/' + property_key)
+        .set(this.header)
+        .end(function(err, result) {
+            if(err) {
+                callback(err);
+            } else {
+                switch(result.statusCode) {
+                    case 204:
+                        callback(null, true); // Index was deleted.
+                        break;
+                    case 404:
+                        callback(null, false); // Index doesn't exist.
+                        break;
+                    default:
+                        callback(new Error('Unknown Error while deleting Index'), null);
+                }
+            }
+        });
 };
 
 function listIndexes (url, callback, header) {
 	request
-	.get(url)
-	.set(header)
-	.end(function(result) {
-		switch(result.statusCode) {
-			case 200:
-			case 204:
-				callback(null, result.body);
-				break;
-			case 404:
-				callback(null, false);
-				break;
-			default:
-				callback(new Error('HTTP Error ' + result.statusCode + ' when listing all indexes.'), null);
-		}
-	});
+        .get(url)
+        .set(header)
+        .end(function(err, result) {
+            if(err) {
+                callback(err);
+            } else {
+                switch(result.statusCode) {
+                    case 200:
+                    case 204:
+                        callback(null, result.body);
+                        break;
+                    case 404:
+                        callback(null, false);
+                        break;
+                    default:
+                        callback(new Error('HTTP Error ' + result.statusCode + ' when listing all indexes.'), null);
+                }
+            }
+        });
 }
 
 Neo4j.prototype.listIndexes = function(indexType, callback) {
@@ -539,17 +589,21 @@ Neo4j.prototype.addItemToIndex = function (args, callback) {
 			'key': args.indexKey,
 			'value': args.indexValue
 		})
-		.end(function(result) {
-			switch(result.statusCode) {
-				case 200:
-					that.addNodeId(result.body, callback);
-					break;
-				case 201:
-					that.addNodeId(result.body, callback);
-					break;
-				default:
-					callback(new Error('HTTP Error ' + result.statusCode + ' when adding an Item to an Index'), null);
-			}
+		.end(function(err, result) {
+            if(err) {
+                callback(err);
+            } else {
+                switch(result.statusCode) {
+                    case 200:
+                        that.addNodeId(result.body, callback);
+                        break;
+                    case 201:
+                        that.addNodeId(result.body, callback);
+                        break;
+                    default:
+                        callback(new Error('HTTP Error ' + result.statusCode + ' when adding an Item to an Index'), null);
+                }
+            }
 		});
 };
 
@@ -599,20 +653,24 @@ Neo4j.prototype.addLabelsToNode = function(nodeId, labels, callback) {
 			.post(url)
 		    .set(this.header)
 			.send(labels)
-			.end(function(result) {
-				switch(result.statusCode) {
-					case 204:
-						callback(null, true); // Labels added
-						break;
-					case 400:
-						callback(new Error(errorMsg), null); // Empty label
-						break;
-					case 404:
-						callback(null, false); // Node doesn't exist
-						break;
-					default:
-						callback(new Error('HTTP Error ' + result.statusCode + ' when adding a label to a node.'), null);
-				}
+			.end(function(err, result) {
+                if(err) {
+                    callback(err);
+                } else {
+                    switch(result.statusCode) {
+                        case 204:
+                            callback(null, true); // Labels added
+                            break;
+                        case 400:
+                            callback(new Error(errorMsg), null); // Empty label
+                            break;
+                        case 404:
+                            callback(null, false); // Node doesn't exist
+                            break;
+                        default:
+                            callback(new Error('HTTP Error ' + result.statusCode + ' when adding a label to a node.'), null);
+                    }
+                }
 			});
 	} else {
 		callback(new Error(errorMsg), null);
@@ -646,20 +704,24 @@ Neo4j.prototype.replaceLabelsFromNode = function(nodeId, labels, callback) {
 			.put(this.url + '/db/data/node/' + nodeId + '/labels')
 			.send(labels)
 		    .set(this.header)
-			.end(function(result) {
-				switch(result.statusCode) {
-					case 204:
-						callback(null, true);
-						break;
-					case 400:
-						callback(new Error(errorMsg), null); // Empty label
-						break;
-					case 404:
-						callback(null, false);
-						break;
-					default:
-						callback(new Error('HTTP Error ' + result.statusCode + ' when replacing labels.'), null);
-			}
+			.end(function(err, result) {
+                if(err) {
+                    callback(err);
+                } else {
+                    switch(result.statusCode) {
+                        case 204:
+                            callback(null, true);
+                            break;
+                        case 400:
+                            callback(new Error(errorMsg), null); // Empty label
+                            break;
+                        case 404:
+                            callback(null, false);
+                            break;
+                        default:
+                            callback(new Error('HTTP Error ' + result.statusCode + ' when replacing labels.'), null);
+		            }
+                }
 		});
 	} else {
 		callback(new Error(errorMsg), null);
@@ -687,18 +749,22 @@ Neo4j.prototype.deleteLabelFromNode = function(nodeId, label, callback) {
 	request
 		.del(this.url + '/db/data/node/' + nodeId + '/labels/'+ label)
 		.set(this.header)
-		.end(function(result) {
-			switch(result.statusCode) {
-				case 204:
-					callback(null, true); // Label was deleted.
-					break;
-				case 404:
-					callback(null, false); // Node doesn't exist.
-					break;
-				default:
-					callback(new Error('Unknown Error while deleting Index'), null);
-		}
-	});
+		.end(function(err, result) {
+            if(err) {
+                callback(err);
+            } else {
+                switch(result.statusCode) {
+                    case 204:
+                        callback(null, true); // Label was deleted.
+                        break;
+                    case 404:
+                        callback(null, false); // Node doesn't exist.
+                        break;
+                    default:
+                        callback(new Error('Unknown Error while deleting Index'), null);
+                }
+            }
+	    });
 };
 
 /*	Get all nodes with a label
@@ -721,34 +787,38 @@ Neo4j.prototype.readNodesWithLabel = function(label, callback) {
 	request
 		.get(this.url + '/db/data/label/' + label + '/nodes')
 		.set(this.header)
-		.end(function(result) {
-			var body = result.body;
-			switch(result.statusCode) {
-				case 200:
-					if (body && body.length >= 1) {
-						step(
-							function addIds() {
-								var group = this.group();
-								body.forEach(function(node) {
-									that.addNodeId(node, group());
-								});
-							},
-							function sumUp(err, nodes) {
-								if (err) {
-									throw err;
-								}
-								callback(null, nodes);
-							});
-					} else {
-						callback(null, body);
-					}
-					break;
-				case 404:
-					callback(null, false);
-					break;
-				default:
-					callback(new Error('HTTP Error ' + result.statusCode + ' when reading a Relationship'), null);
-			}
+		.end(function(err, result) {
+            if(err) {
+                callback(err);
+            } else {
+                var body = result.body;
+                switch(result.statusCode) {
+                    case 200:
+                        if (body && body.length >= 1) {
+                            step(
+                                function addIds() {
+                                    var group = this.group();
+                                    body.forEach(function(node) {
+                                        that.addNodeId(node, group());
+                                    });
+                                },
+                                function sumUp(err, nodes) {
+                                    if (err) {
+                                        throw err;
+                                    }
+                                    callback(null, nodes);
+                                });
+                        } else {
+                            callback(null, body);
+                        }
+                        break;
+                    case 404:
+                        callback(null, false);
+                        break;
+                    default:
+                        callback(new Error('HTTP Error ' + result.statusCode + ' when reading a Relationship'), null);
+                }
+            }
 		});
 };
 
@@ -776,34 +846,38 @@ Neo4j.prototype.readNodesWithLabelsAndProperties = function(labels, properties, 
 		request
 			.get(this.url + '/db/data/label/' + labels + '/nodes?' + props)
 			.set(this.header)
-			.end(function(result) {
-				var body = result.body;
-				switch(result.statusCode) {
-					case 200:
-						if (body && body.length >= 1) {
-							step(
-								function addIds(){
-									var group = this.group();
-									body.forEach(function(node){
-										that.addNodeId(node, group());
-									});
-								},
-								function sumUp(err, nodes){
-									if(err) {
-										throw err;
-									}
-									callback(null, nodes);
-								});
-						} else {
-							callback(null, body);
-						}
-						break;
-					case 404:
-						callback(null, false);
-						break;
-					default:
-						callback(new Error('HTTP Error ' + result.statusCode + ' when reading Nodes.'), null);
-				}
+			.end(function(err, result) {
+                if(err) {
+                    callback(err);
+                } else {
+                    var body = result.body;
+                    switch(result.statusCode) {
+                        case 200:
+                            if (body && body.length >= 1) {
+                                step(
+                                    function addIds(){
+                                        var group = this.group();
+                                        body.forEach(function(node){
+                                            that.addNodeId(node, group());
+                                        });
+                                    },
+                                    function sumUp(err, nodes){
+                                        if(err) {
+                                            throw err;
+                                        }
+                                        callback(null, nodes);
+                                    });
+                            } else {
+                                callback(null, body);
+                            }
+                            break;
+                        case 404:
+                            callback(null, false);
+                            break;
+                        default:
+                            callback(new Error('HTTP Error ' + result.statusCode + ' when reading Nodes.'), null);
+                    }
+                }
 			});
 		} else { // Multiple labels or properties provided
 			var query = 'MATCH (data'+  cypher.labels(labels) + ') WHERE ' + cypher.where('data', properties) + ' RETURN data';
@@ -826,17 +900,21 @@ Neo4j.prototype.listAllLabels = function(callback) {
 	request
 	.get(this.url + '/db/data/labels')
 	.set(this.header)
-	.end(function(result) {
-		switch(result.statusCode) {
-			case 200:
-				callback(null, result.body);
-				break;
-			case 404:
-				callback(null, false);
-				break;
-			default:
-				callback(new Error('HTTP Error ' + result.statusCode + ' when listing all labels.'), null);
-		}
+	.end(function(err, result) {
+        if(err) {
+            callback(err);
+        } else {
+            switch(result.statusCode) {
+                case 200:
+                    callback(null, result.body);
+                    break;
+                case 404:
+                    callback(null, false);
+                    break;
+                default:
+                    callback(new Error('HTTP Error ' + result.statusCode + ' when listing all labels.'), null);
+            }
+        }
 	});
 };
 
@@ -864,17 +942,21 @@ var createUniquenessConstraint = function(label, property_key, callback) {
 		.post(that.url + '/db/data/schema/constraint/' + label + '/uniqueness')
 		.set(this.header)
 		.send({ 'property_keys' : [property_key] })
-		.end(function(result) {
-			switch(result.statusCode) {
-				case 200:
-					callback(null, result.body);
-					break;
-				case 409:
-					callback(null, false); // Constraint already exists
-					break;
-				default:
-					callback(new Error('HTTP Error ' + result.statusCode + ' when creating a uniqueness contraint.'), null);
-			}
+		.end(function(err, result) {
+            if(err) {
+                callback(err);
+            } else {
+                switch(result.statusCode) {
+                    case 200:
+                        callback(null, result.body);
+                        break;
+                    case 409:
+                        callback(null, false); // Constraint already exists
+                        break;
+                    default:
+                        callback(new Error('HTTP Error ' + result.statusCode + ' when creating a uniqueness contraint.'), null);
+                }
+            }
 		});
 };
 Neo4j.prototype.createUniquenessConstraint = createUniquenessConstraint;
@@ -900,17 +982,21 @@ Neo4j.prototype.readUniquenessConstraint = function(label, property, callback) {
 	request
 		.get(this.url + '/db/data/schema/constraint/' + label + '/uniqueness/' + property)
 		.set(this.header)
-		.end(function(result) {
-			switch(result.statusCode) {
-				case 200:
-					callback(null, result.body);
-					break;
-				case 404:
-					callback(null, false);
-					break;
-				default:
-					callback(new Error('HTTP Error ' + result.statusCode + ' when reading uniqueness constraints'), null);
-			}
+		.end(function(err, result) {
+            if(err) {
+                callback(err);
+            } else {
+                switch(result.statusCode) {
+                    case 200:
+                        callback(null, result.body);
+                        break;
+                    case 404:
+                        callback(null, false);
+                        break;
+                    default:
+                        callback(new Error('HTTP Error ' + result.statusCode + ' when reading uniqueness constraints'), null);
+                }
+            }
 	});
 };
 
@@ -937,17 +1023,21 @@ Neo4j.prototype.listAllUniquenessConstraintsForLabel = function(label, callback)
 	request
 		.get(this.url + '/db/data/schema/constraint/' + label + '/uniqueness')
 		.set(this.header)
-		.end(function(result) {
-			switch(result.statusCode) {
-				case 200:
-					callback(null, result.body);
-					break;
-				case 404:
-					callback(null, false);
-					break;
-				default:
-					callback(new Error('HTTP Error ' + result.statusCode + ' when listing all uniqueness constraints.'), null);
-			}
+		.end(function(err, result) {
+            if(err) {
+                callback(err);
+            } else {
+                switch(result.statusCode) {
+                    case 200:
+                        callback(null, result.body);
+                        break;
+                    case 404:
+                        callback(null, false);
+                        break;
+                    default:
+                        callback(new Error('HTTP Error ' + result.statusCode + ' when listing all uniqueness constraints.'), null);
+                }
+            }
 	});
 };
 
@@ -972,20 +1062,24 @@ Neo4j.prototype.listAllConstraintsForLabel = function(label, callback) {
 	}
 
 	request
-	.get(this.url + '/db/data/schema/constraint/' + label)
-	.set(this.header)
-	.end(function(result) {
-		switch(result.statusCode) {
-			case 200:
-				callback(null, result.body);
-				break;
-			case 404:
-				callback(null, false);
-				break;
-			default:
-				callback(new Error('HTTP Error ' + result.statusCode + ' when listing all constraints.'), null);
-		}
-	});
+        .get(this.url + '/db/data/schema/constraint/' + label)
+        .set(this.header)
+        .end(function(err, result) {
+            if(err) {
+                callback(err);
+            } else {
+                switch(result.statusCode) {
+                    case 200:
+                        callback(null, result.body);
+                        break;
+                    case 404:
+                        callback(null, false);
+                        break;
+                    default:
+                        callback(new Error('HTTP Error ' + result.statusCode + ' when listing all constraints.'), null);
+                }
+            }
+        });
 };
 
 
@@ -1004,20 +1098,24 @@ Neo4j.prototype.listAllConstraintsForLabel = function(label, callback) {
 
 Neo4j.prototype.listAllConstraints = function(callback) {
 	request
-	.get(this.url + '/db/data/schema/constraint')
-	.set(this.header)
-	.end(function(result) {
-		switch(result.statusCode) {
-			case 200:
-				callback(null, result.body);
-				break;
-			case 404:
-				callback(null, false);
-				break;
-			default:
-				callback(new Error('HTTP Error ' + result.statusCode + ' when listing all constraints.'), null);
-		}
-	});
+        .get(this.url + '/db/data/schema/constraint')
+        .set(this.header)
+        .end(function(err, result) {
+            if(err) {
+                callback(err);
+            } else {
+                switch(result.statusCode) {
+                    case 200:
+                        callback(null, result.body);
+                        break;
+                    case 404:
+                        callback(null, false);
+                        break;
+                    default:
+                        callback(new Error('HTTP Error ' + result.statusCode + ' when listing all constraints.'), null);
+                }
+            }
+        });
 };
 
 /*	Drop uniqueness constraint for a label and a property.
@@ -1038,17 +1136,21 @@ Neo4j.prototype.dropUniquenessContstraint = function(label, property_key, callba
 	request
 		.del(this.url + '/db/data/schema/constraint/' + label + '/uniqueness/' + property_key)
 		.set(this.header)
-		.end(function(result) {
-			switch(result.statusCode) {
-				case 204:
-					callback(null, true); // Constraint was deleted.
-					break;
-				case 404:
-					callback(null, false); // Constraint doesn't exist.
-					break;
-				default:
-					callback(new Error('HTTP Error ' + result.statusCode + ' when removing a uniqueness contraint.'), null);
-			}
+		.end(function(err, result) {
+            if(err) {
+                callback(err);
+            } else {
+                switch(result.statusCode) {
+                    case 204:
+                        callback(null, true); // Constraint was deleted.
+                        break;
+                    case 404:
+                        callback(null, false); // Constraint doesn't exist.
+                        break;
+                    default:
+                        callback(new Error('HTTP Error ' + result.statusCode + ' when removing a uniqueness contraint.'), null);
+                }
+            }
 		});
 };
 
@@ -1121,17 +1223,21 @@ Neo4j.prototype.beginTransaction = function(statements, callback) {
 		.post(this.url + '/db/data/transaction')
 		.set(this.header)
 		.send(statements)
-		.end(function(result) {
-			switch(result.statusCode) {
-				case 201:
-					that.addTransactionId(result.body, callback);
-					break;
-				case 404:
-					callback(null, false);
-					break;
-				default:
-					callback(new Error('HTTP Error ' + result.statusCode + ' when beginning transaction.'), null);
-			}
+		.end(function(err, result) {
+            if(err) {
+                callback(err);
+            } else {
+                switch(result.statusCode) {
+                    case 201:
+                        that.addTransactionId(result.body, callback);
+                        break;
+                    case 404:
+                        callback(null, false);
+                        break;
+                    default:
+                        callback(new Error('HTTP Error ' + result.statusCode + ' when beginning transaction.'), null);
+                }
+            }
 		});
 };
 
@@ -1176,23 +1282,27 @@ Neo4j.prototype.addStatementsToTransaction = function(transactionId, statements,
 		.post(this.url + '/db/data/transaction/' + transactionId)
 		.set(this.header)
 		.send(statements)
-		.end(function(result) {
-			switch(result.statusCode) {
-				case 200:
-					that.addTransactionId(result.body, function afterAddingTransactionId (err, res) {
-						if (res.errors && res.errors.length > 0) {
-							callback(new Error('An error occured when adding statements to the transaction. See "errors" inside the result for more details.'), res);
-						} else {
-							callback(null, res);
-						}
-					});
-					break;
-				case 404:
-					callback(null, false); // Transaction doesn't exist.
-					break;
-				default:
-					callback(new Error('HTTP Error ' + result.statusCode + ' when adding statements to transaction.'), null);
-			}
+		.end(function(err, result) {
+            if(err) {
+                callback(err);
+            } else {
+                switch(result.statusCode) {
+                    case 200:
+                        that.addTransactionId(result.body, function afterAddingTransactionId (err, res) {
+                            if (res.errors && res.errors.length > 0) {
+                                callback(new Error('An error occured when adding statements to the transaction. See "errors" inside the result for more details.'), res);
+                            } else {
+                                callback(null, res);
+                            }
+                        });
+                        break;
+                    case 404:
+                        callback(null, false); // Transaction doesn't exist.
+                        break;
+                    default:
+                        callback(new Error('HTTP Error ' + result.statusCode + ' when adding statements to transaction.'), null);
+                }
+            }
 		});
 };
 
@@ -1227,17 +1337,21 @@ Neo4j.prototype.resetTimeoutTransaction = function(transactionId, callback) {
 		.post(this.url + '/db/data/transaction/' + transactionId)
 		.set(this.header)
 		.send({ statements : [ ]})
-		.end(function(result) {
-			switch(result.statusCode) {
-				case 200:
-					that.addTransactionId(result.body, callback);
-					break;
-				case 404:
-					callback(null, false); // Transaction doesn't exist.
-					break;
-				default:
-					callback(new Error('HTTP Error ' + result.statusCode + ' when resetting transaction timeout.'), null);
-			}
+		.end(function(err, result) {
+            if(err) {
+                callback(err);
+            } else {
+                switch(result.statusCode) {
+                    case 200:
+                        that.addTransactionId(result.body, callback);
+                        break;
+                    case 404:
+                        callback(null, false); // Transaction doesn't exist.
+                        break;
+                    default:
+                        callback(new Error('HTTP Error ' + result.statusCode + ' when resetting transaction timeout.'), null);
+                }
+            }
 		});
 };
 
@@ -1289,17 +1403,21 @@ Neo4j.prototype.commitTransaction = function(transactionId, statements, callback
 		.post(this.url + '/db/data/transaction/' + transactionId + '/commit')
 		.set(this.header)
 		.send(statements)
-		.end(function(result) {
-			switch(result.statusCode) {
-				case 200:
-					callback(null, result.body);
-					break;
-				case 404:
-					callback(null, false); // Transaction doesn't exist.
-					break;
-				default:
-					callback(new Error('HTTP Error ' + result.statusCode + ' when commiting transaction.'), null);
-			}
+		.end(function(err, result) {
+            if(err) {
+                callback(err);
+            } else {
+                switch(result.statusCode) {
+                    case 200:
+                        callback(null, result.body);
+                        break;
+                    case 404:
+                        callback(null, false); // Transaction doesn't exist.
+                        break;
+                    default:
+                        callback(new Error('HTTP Error ' + result.statusCode + ' when commiting transaction.'), null);
+                }
+            }
 		});
 };
 
@@ -1327,17 +1445,21 @@ Neo4j.prototype.rollbackTransaction = function(transactionId, callback) {
 	request
 		.del(this.url + '/db/data/transaction/' + transactionId)
 		.set(this.header)
-		.end(function(result) {
-			switch(result.statusCode) {
-				case 200:
-					callback(null, true);
-					break;
-				case 404:
-					callback(null, false); // Transaction doesn't exist.
-					break;
-				default:
-					callback(new Error('HTTP Error ' + result.statusCode + ' when rolling back transaction.'), null);
-			}
+		.end(function(err, result) {
+            if(err) {
+                callback(err);
+            } else {
+                switch(result.statusCode) {
+                    case 200:
+                        callback(null, true);
+                        break;
+                    case 404:
+                        callback(null, false); // Transaction doesn't exist.
+                        break;
+                    default:
+                        callback(new Error('HTTP Error ' + result.statusCode + ' when rolling back transaction.'), null);
+                }
+            }
 		});
 };
 
@@ -1405,17 +1527,21 @@ Neo4j.prototype.beginAndCommitTransaction = function(statements, callback) {
 		.set(this.header)
 		.set('X-Stream', true)
 		.send(statements)
-		.end(function(result) {
-			switch(result.statusCode) {
-				case 200:
-					callback(null, result.body);
-					break;
-				case 404:
-					callback(null, false); // Transaction doesn't exist.
-					break;
-				default:
-					callback(new Error('HTTP Error ' + result.statusCode + ' when beginning and commiting transaction.'), null);
-			}
+		.end(function(err, result) {
+            if(err) {
+                callback(err);
+            } else {
+                switch(result.statusCode) {
+                    case 200:
+                        callback(null, result.body);
+                        break;
+                    case 404:
+                        callback(null, false); // Transaction doesn't exist.
+                        break;
+                    default:
+                        callback(new Error('HTTP Error ' + result.statusCode + ' when beginning and commiting transaction.'), null);
+                }
+            }
 		});
 };
 
@@ -1429,14 +1555,18 @@ Neo4j.prototype.readRelationshipTypes = function(callback) {
 	request
 		.get(that.url + '/db/data/relationship/types')
 		.set(this.header)
-		.end(function(result) {
-			switch(result.statusCode) {
-				case 200:
-					callback(null, result.body);
-					break;
-				default:
-					callback(new Error('HTTP Error ' + result.statusCode + ' when retrieving relationship types.'), null);
-			}
+		.end(function(err, result) {
+            if(err) {
+                callback(err);
+            } else {
+                switch(result.statusCode) {
+                    case 200:
+                        callback(null, result.body);
+                        break;
+                    default:
+                        callback(new Error('HTTP Error ' + result.statusCode + ' when retrieving relationship types.'), null);
+                }
+            }
 		});
 };
 
@@ -1466,17 +1596,21 @@ var readRelationshipsOfNode = function(node_id, options, callback) {
 	request
 		.get(url)
 		.set(this.header)
-		.end(function(result) {
-			switch(result.statusCode) {
-				case 200:
-					that.addRelationshipIdForArray(result.body, callback);
-					break;
-				case 404:
-					callback(null, false);
-					break;
-				default:
-					callback(new Error('HTTP Error ' + result.statusCode + ' when retrieving relationships for node ' + node_id), null);
-			}
+		.end(function(err, result) {
+            if(err) {
+                callback(err);
+            } else {
+                switch(result.statusCode) {
+                    case 200:
+                        that.addRelationshipIdForArray(result.body, callback);
+                        break;
+                    case 404:
+                        callback(null, false);
+                        break;
+                    default:
+                        callback(new Error('HTTP Error ' + result.statusCode + ' when retrieving relationships for node ' + node_id), null);
+                }
+            }
 		});
 };
 // Create aliases
@@ -1517,58 +1651,62 @@ Neo4j.prototype.cypherQuery = function(query, params, include_stats, callback) {
 		.set(this.header)
 		.set('Content-Type', 'application/json')
 		.send(body)
-    .on('error', callback)
-		.end(function(result) {
-			switch(result.statusCode) {
-				case 200:
-					if (result.body && result.body.data.length >= 1) {
-						var addIdsToColumnData = function(columnData, callback) {
-							step(
-								function addId() {
-									var group = this.group();
-									columnData.forEach(function(node) {
-										that.addNodeId(node, group());
-									});
-								},
-								function sumUp(err, nodes) {
-									if (err) {
-										throw err;
-									} else {
-										callback(null, nodes);
-									}
-								});
-						};
+        .on('error', callback)
+		.end(function(err, result) {
+            if(err) {
+                callback(err);
+            } else {
+                switch(result.statusCode) {
+                    case 200:
+                        if (result.body && result.body.data.length >= 1) {
+                            var addIdsToColumnData = function(columnData, callback) {
+                                step(
+                                    function addId() {
+                                        var group = this.group();
+                                        columnData.forEach(function(node) {
+                                            that.addNodeId(node, group());
+                                        });
+                                    },
+                                    function sumUp(err, nodes) {
+                                        if (err) {
+                                            throw err;
+                                        } else {
+                                            callback(null, nodes);
+                                        }
+                                    });
+                            };
 
-						step(
-							function eachColumn() {
-								var group = this.group();
-								result.body.data.forEach(function(columnResult) {
-									addIdsToColumnData(columnResult, group());
-								});
-							},
-							function sumUp(err, columns) {
-								if (err) {
-									throw err;
-								} else {
-									// flatten the array if only one variable is getting returned to make it more convenient.
-									if (result.body.columns.length >= 2) {
-										result.body.data = columns;
-									} else {
-										result.body.data = [].concat.apply([], columns);
-									}
-									callback(null, result.body);
-								}
-							});
-					} else {
-						callback(null, result.body);
-					}
-					break;
-				case 404:
-					callback(null, null);
-					break;
-				default:
-					callback(new Error('HTTP Error ' + result.statusCode + ' when running the cypher query against neo4j.\n' + result.body.exception + ': ' + result.body.message), null);
-			}
+                            step(
+                                function eachColumn() {
+                                    var group = this.group();
+                                    result.body.data.forEach(function(columnResult) {
+                                        addIdsToColumnData(columnResult, group());
+                                    });
+                                },
+                                function sumUp(err, columns) {
+                                    if (err) {
+                                        throw err;
+                                    } else {
+                                        // flatten the array if only one variable is getting returned to make it more convenient.
+                                        if (result.body.columns.length >= 2) {
+                                            result.body.data = columns;
+                                        } else {
+                                            result.body.data = [].concat.apply([], columns);
+                                        }
+                                        callback(null, result.body);
+                                    }
+                                });
+                        } else {
+                            callback(null, result.body);
+                        }
+                        break;
+                    case 404:
+                        callback(null, null);
+                        break;
+                    default:
+                        callback(new Error('HTTP Error ' + result.statusCode + ' when running the cypher query against neo4j.\n' + result.body.exception + ': ' + result.body.message), null);
+                }
+            }
 		});
 };
 
@@ -1583,17 +1721,21 @@ Neo4j.prototype.batchQuery = function(query, callback) {
 		.set(this.header)
 		.set('Content-Type', 'application/json')
 		.send(query)
-		.end(function(result) {
-			switch(result.statusCode) {
-				case 200:
-					callback(null, result.body);
-					break;
-				case 404:
-					callback(null, null);
-					break;
-				default:
-					callback(new Error('HTTP Error ' + result.statusCode + ' when running the batch query against neo4j'), null);
-			}
+		.end(function(err, result) {
+            if(err) {
+                callback(err);
+            } else {
+                switch(result.statusCode) {
+                    case 200:
+                        callback(null, result.body);
+                        break;
+                    case 404:
+                        callback(null, null);
+                        break;
+                    default:
+                        callback(new Error('HTTP Error ' + result.statusCode + ' when running the batch query against neo4j'), null);
+                }
+            }
 		});
 };
 


### PR DESCRIPTION
#62: I added an 'error' argument to all the callbacks for superagent requests. This prevents the node process from exiting when an error like ECONNREFUSED is encountered, which could happen in the case that a neo4j instance isn't running.
